### PR TITLE
Pcm gha licenses export

### DIFF
--- a/.github/workflows/export-licenses.yml
+++ b/.github/workflows/export-licenses.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "15 2 * * *"
   workflow_dispatch:
-  push:
 
 jobs:
   build_and_export_licences:

--- a/.github/workflows/export-licenses.yml
+++ b/.github/workflows/export-licenses.yml
@@ -1,0 +1,27 @@
+name: Export licenses
+
+on:
+  schedule:
+    - cron: "15 2 * * *"
+  workflow_dispatch:
+  push:
+
+jobs:
+  build_and_export_licences:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+    - uses: actions/checkout@v4
+    - uses: annotell/gha-pybuild/build-setup@v2
+      with:
+        python-version: '3.10'
+        cache-key-version: 'audit'
+        skip-install: 'true'
+    - uses: annotell/gha-pybuild/build-licenses-export@v2
+  upload:
+    needs: build_and_export_licences
+    uses: annotell/gha-supply-chain/.github/workflows/reusable-license-uploader.yaml@v0.1.0
+    with:
+        language: python


### PR DESCRIPTION
GHA for exporting licenses.
Scheduled to run daily, 02:15, with possibility of triggering it manually.
It relies on a service account provided by PlatEng, with minimal rights for reading what needed and only writing to a dedicated bucket created in the supply chain gcp project.
Comprehensive documentation will be kept [here](https://app.gitbook.com/o/-LDaVCx2pY3vjODE3oJm/s/-LDaVDUHV9DHJpWHFdzp/writing-code/devops/licenses)