### PR TITLE
Log a warning if the token is likely bad

### DIFF
--- a/src/kognic/auth/base/auth_client.py
+++ b/src/kognic/auth/base/auth_client.py
@@ -9,7 +9,10 @@ log = logging.getLogger(__name__)
 
 class AuthClient:
     def _log_new_token(self):
-        log.info(f"Got new token, with ttl={self.token['expires_in']} and expires {self.expires_at}")
+        if "expires_in" in self.token:
+            log.info(f"Got new token, with ttl={self.token['expires_in']} and expires {self.expires_at}")
+        else:
+            log.warning(f"Got new token that is likely not valid: {self.token}")
 
     @property
     def access_token(self):

--- a/src/kognic/auth/base/auth_client.py
+++ b/src/kognic/auth/base/auth_client.py
@@ -12,7 +12,7 @@ class AuthClient:
         if "expires_in" in self.token:
             log.info(f"Got new token, with ttl={self.token['expires_in']} and expires {self.expires_at}")
         else:
-            log.warning(f"Got new token that is likely not valid: {self.token}")
+            log.warning(f"Got new token that is likely not valid: missing expires_in but got {self.token.keys()}")
 
     @property
     def access_token(self):


### PR DESCRIPTION
From a support ping to team order.

Sometimes logging a refreshed auth token fails because the response doesn't contain the expiry time. Since this is only logging, it's a shame to get an error here. This attempts to turn the error into a warning of problems to come. Auth will still likely not have worked.

Users are seeing this now with KIO 2.4.0 against prod, we don't know why. Seems the auth-api is happily handing out tokens to the user in question. But this might shed some light on what the response contains.

Edit: the response contains 429 rate limit exceeded errors. Attempt to surface those here: #35 