### PR TITLE
Log an error when auth rate limit is encountered

### DIFF
--- a/src/kognic/auth/base/auth_client.py
+++ b/src/kognic/auth/base/auth_client.py
@@ -31,3 +31,9 @@ class AuthClient:
     @property
     def token(self):
         raise NotImplementedError
+
+    @staticmethod
+    def check_rate_limit(response):
+        if response.status_code == 429:
+            log.error("Client authentication rate limit exceeded! Please slow down.")
+        return response

--- a/src/kognic/auth/httpx/async_client.py
+++ b/src/kognic/auth/httpx/async_client.py
@@ -57,6 +57,8 @@ class HttpxAuthAsyncClient(AuthClient):
             grant_type="client_credentials",
             **kwargs,
         )
+        self._oauth_client.register_compliance_hook("access_token_response", AuthClient.check_rate_limit)
+        self._oauth_client.register_compliance_hook("refresh_token_response", AuthClient.check_rate_limit)
 
         self._lock = Lock()
 

--- a/src/kognic/auth/requests/auth_session.py
+++ b/src/kognic/auth/requests/auth_session.py
@@ -68,6 +68,8 @@ class RequestsAuthSession(AuthClient):
             token_endpoint=self.token_url,
             **kwargs,
         )
+        self.oauth_session.register_compliance_hook("access_token_response", AuthClient.check_rate_limit)
+        self.oauth_session.register_compliance_hook("refresh_token_response", AuthClient.check_rate_limit)
 
         self._lock = threading.RLock()
 


### PR DESCRIPTION
Currently this fails in an obscure way when trying to log the response since it doesn't have the expiry. Since it's a 400-class error it isn't turned into an exception by OAuth2Client, and just kind of gets fumbled until it lands here:

```
  File "/usr/local/lib/python3.11/site-packages/kognic/auth/base/auth_client.py", line 12, in _log_new_token
    log.info(f"Got new token, with ttl={self.token['expires_in']} and expires {self.expires_at}")
                                        ~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'expires_in'
```

This PR adds a 'compliance hook' on the OAuth2 session that checks the response code and logs an error if the rate limit was hit.

This will not address the exception above, but provides some context in the logs. #34 will help with the bad error outcome.