### PR TITLE
fix(cli): forward environment scopes when requesting token in kog

### DIFF
--- a/src/kognic/auth/cli/api_request.py
+++ b/src/kognic/auth/cli/api_request.py
@@ -86,7 +86,10 @@ def run(parsed: argparse.Namespace) -> int:
         env = resolve_environment(config, parsed.url, parsed.env_name)
 
         provider = make_token_provider(
-            auth=env.credentials, auth_host=env.auth_server, token_cache=make_cache(parsed.token_cache)
+            auth=env.credentials,
+            auth_host=env.auth_server,
+            token_cache=make_cache(parsed.token_cache),
+            scopes=env.scopes,
         )
         session = create_session(token_provider=provider)
 

--- a/src/kognic/auth/cli/api_request.py
+++ b/src/kognic/auth/cli/api_request.py
@@ -89,7 +89,7 @@ def run(parsed: argparse.Namespace) -> int:
             auth=env.credentials,
             auth_host=env.auth_server,
             token_cache=make_cache(parsed.token_cache),
-            scopes=env.scopes,
+            scopes=env.scopes or None,
         )
         session = create_session(token_provider=provider)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1118,7 +1118,7 @@ class CallApiTest(unittest.TestCase):
                 auth="/path/to/demo-creds.json",
                 auth_host="https://auth.demo.kognic.com",
                 token_cache=None,
-                scopes=[],
+                scopes=None,
             )
 
     @mock.patch("kognic.auth.cli.api_request.resolve_environment")
@@ -1160,7 +1160,7 @@ class CallApiTest(unittest.TestCase):
     @mock.patch("kognic.auth.cli.api_request.resolve_environment")
     @mock.patch("kognic.auth.cli.api_request.load_kognic_env_config")
     def test_call_api_empty_scopes_forwarded(self, mock_load_config, mock_resolve_environment):
-        """An environment without configured scopes forwards an empty list (no scopes requested)."""
+        """An environment without configured scopes forwards None, so the credentials-file scope fallback applies."""
         mock_load_config.return_value = mock.MagicMock()
         mock_resolve_environment.return_value = Environment(
             name="default",
@@ -1189,7 +1189,7 @@ class CallApiTest(unittest.TestCase):
                 auth=None,
                 auth_host="https://auth.app.kognic.com",
                 token_cache=None,
-                scopes=[],
+                scopes=None,
             )
 
 
@@ -1237,7 +1237,7 @@ class KogCacheTest(unittest.TestCase):
             auth=None,
             auth_host="https://auth.app.kognic.com",
             token_cache=None,
-            scopes=[],
+            scopes=None,
         )
 
     @mock.patch("kognic.auth.cli.api_request.resolve_environment")
@@ -1283,7 +1283,7 @@ class KogCacheTest(unittest.TestCase):
             auth="/path/to/creds.json",
             auth_host="https://auth.app.kognic.com",
             token_cache=mock_cache,
-            scopes=[],
+            scopes=None,
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1118,6 +1118,78 @@ class CallApiTest(unittest.TestCase):
                 auth="/path/to/demo-creds.json",
                 auth_host="https://auth.demo.kognic.com",
                 token_cache=None,
+                scopes=[],
+            )
+
+    @mock.patch("kognic.auth.cli.api_request.resolve_environment")
+    @mock.patch("kognic.auth.cli.api_request.load_kognic_env_config")
+    def test_call_api_forwards_env_scopes(self, mock_load_config, mock_resolve_environment):
+        """The resolved environment's scopes are forwarded to make_token_provider."""
+        mock_load_config.return_value = mock.MagicMock()
+        mock_resolve_environment.return_value = Environment(
+            name="staging",
+            host="staging.kognic.com",
+            auth_server="https://auth.staging.kognic.com",
+            credentials="/path/to/staging-creds.json",
+            scopes=["api:read"],
+        )
+
+        with (
+            mock.patch("kognic.auth.cli.api_request.make_token_provider") as mock_make_provider,
+            mock.patch("kognic.auth.cli.api_request.create_session") as mock_create_session,
+        ):
+            mock_session = mock.MagicMock()
+            mock_response = mock.MagicMock()
+            mock_response.ok = True
+            mock_response.headers = {"Content-Type": "text/plain"}
+            mock_response.text = "ok"
+            mock_session.request.return_value = mock_response
+            mock_create_session.return_value = mock_session
+
+            parsed = self._make_parsed(url="https://staging.kognic.com/v1/projects")
+            with mock.patch("builtins.print"):
+                call_run(parsed)
+
+            mock_make_provider.assert_called_once_with(
+                auth="/path/to/staging-creds.json",
+                auth_host="https://auth.staging.kognic.com",
+                token_cache=None,
+                scopes=["api:read"],
+            )
+
+    @mock.patch("kognic.auth.cli.api_request.resolve_environment")
+    @mock.patch("kognic.auth.cli.api_request.load_kognic_env_config")
+    def test_call_api_empty_scopes_forwarded(self, mock_load_config, mock_resolve_environment):
+        """An environment without configured scopes forwards an empty list (no scopes requested)."""
+        mock_load_config.return_value = mock.MagicMock()
+        mock_resolve_environment.return_value = Environment(
+            name="default",
+            host="app.kognic.com",
+            auth_server="https://auth.app.kognic.com",
+            credentials=None,
+        )
+
+        with (
+            mock.patch("kognic.auth.cli.api_request.make_token_provider") as mock_make_provider,
+            mock.patch("kognic.auth.cli.api_request.create_session") as mock_create_session,
+        ):
+            mock_session = mock.MagicMock()
+            mock_response = mock.MagicMock()
+            mock_response.ok = True
+            mock_response.headers = {"Content-Type": "text/plain"}
+            mock_response.text = "ok"
+            mock_session.request.return_value = mock_response
+            mock_create_session.return_value = mock_session
+
+            parsed = self._make_parsed()
+            with mock.patch("builtins.print"):
+                call_run(parsed)
+
+            mock_make_provider.assert_called_once_with(
+                auth=None,
+                auth_host="https://auth.app.kognic.com",
+                token_cache=None,
+                scopes=[],
             )
 
 
@@ -1165,6 +1237,7 @@ class KogCacheTest(unittest.TestCase):
             auth=None,
             auth_host="https://auth.app.kognic.com",
             token_cache=None,
+            scopes=[],
         )
 
     @mock.patch("kognic.auth.cli.api_request.resolve_environment")
@@ -1210,6 +1283,7 @@ class KogCacheTest(unittest.TestCase):
             auth="/path/to/creds.json",
             auth_host="https://auth.app.kognic.com",
             token_cache=mock_cache,
+            scopes=[],
         )
 
 

--- a/tests/test_requests_auth.py
+++ b/tests/test_requests_auth.py
@@ -31,6 +31,10 @@ class TestMakeTokenProviderScopeResolution(unittest.TestCase):
         provider = make_token_provider(auth=_creds_with_scopes(["api:read"]), scopes=["api:write"])
         self.assertEqual(provider.oauth_session.scope, "api:write")
 
+    def test_multiple_scopes_are_space_joined(self):
+        provider = make_token_provider(auth=_creds_with_scopes(["api:read"]), scopes=["api:read", "api:write"])
+        self.assertEqual(provider.oauth_session.scope, "api:read api:write")
+
     def test_none_scopes_fall_back_to_credentials_scopes(self):
         provider = make_token_provider(auth=_creds_with_scopes(["api:read"]), scopes=None)
         self.assertEqual(provider.oauth_session.scope, "api:read")

--- a/tests/test_requests_auth.py
+++ b/tests/test_requests_auth.py
@@ -6,8 +6,40 @@ from unittest.mock import MagicMock, patch
 import requests
 from authlib.common.errors import AuthlibBaseError
 
+from kognic.auth.credentials_parser import ApiCredentials
 from kognic.auth.requests.auth_session import _FixedSession
+from kognic.auth.requests.base_client import make_token_provider
 from kognic.auth.requests.bearer_auth import KognicBearerAuth
+
+
+def _creds_with_scopes(scopes):
+    """Return ApiCredentials that declare the given scopes."""
+    return ApiCredentials(
+        client_id="test-id",
+        client_secret="test-secret",
+        email="test@kognic.com",
+        user_id=1,
+        issuer="test-issuer",
+        scopes=scopes,
+    )
+
+
+class TestMakeTokenProviderScopeResolution(unittest.TestCase):
+    """The requested scope depends on how None vs an empty list interact with credentials-file scopes."""
+
+    def test_explicit_scopes_override_credentials_scopes(self):
+        provider = make_token_provider(auth=_creds_with_scopes(["api:read"]), scopes=["api:write"])
+        self.assertEqual(provider.oauth_session.scope, "api:write")
+
+    def test_none_scopes_fall_back_to_credentials_scopes(self):
+        provider = make_token_provider(auth=_creds_with_scopes(["api:read"]), scopes=None)
+        self.assertEqual(provider.oauth_session.scope, "api:read")
+
+    def test_empty_scopes_suppress_credentials_fallback(self):
+        # An empty list is not None, so the credentials-file fallback is skipped and no scope is requested.
+        # This is why kog forwards `env.scopes or None` rather than the raw (possibly empty) list.
+        provider = make_token_provider(auth=_creds_with_scopes(["api:read"]), scopes=[])
+        self.assertIsNone(provider.oauth_session.scope)
 
 
 def _make_fixed_session():


### PR DESCRIPTION
## Summary
- The `kog` command ignored the scopes configured for an environment when fetching a token, so tokens always carried the client's full default grant (e.g. `api:read api:write`).
- This meant an environment locked to `api:read` still produced a write-capable token, and writes (POST/PATCH/DELETE) unexpectedly succeeded against it.
- `kog` now requests exactly the scopes configured for the environment, matching the behaviour of `get-access-token` and the API client. Environments without configured scopes are unaffected.