### PR TITLE
feat(cli): add per-invocation --scope flag to kog

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ kognic-auth credentials delete --env example
 Make an authenticated HTTP request to a Kognic API. Think of `kog` as a lightweight `curl` that automatically handles authentication and environment resolution.
 
 ```bash
-kog <METHOD> URL [-d DATA] [-H HEADER] [--format FORMAT] [--env NAME] [--env-config-file-path FILE]
+kog <METHOD> URL [-d DATA] [-H HEADER] [--format FORMAT] [--env NAME] [--env-config-file-path FILE] [--scope SCOPE]
 ```
 
 **Options:**
@@ -218,6 +218,7 @@ kog <METHOD> URL [-d DATA] [-H HEADER] [--format FORMAT] [--env NAME] [--env-con
 - `--format` - Output format (default: `json`). See [Output formats](#output-formats) below.
 - `--env` - Force a specific environment (skip URL-based matching)
 - `--env-config-file-path` - Environment config file path (default: `~/.config/kognic/environments.json`)
+- `--scope` - OAuth2 scope to request (repeatable, e.g. `--scope api:read --scope api:write`). See [Per-invocation scopes](#per-invocation-scopes) below.
 
 When `--env` is not provided, the environment is automatically resolved by matching the request URL's hostname against the `host` field of each environment in the config file.
 
@@ -235,6 +236,23 @@ kog post https://app.kognic.com/v1/projects -d '{"name": "test"}'
 # Custom headers
 kog get https://app.kognic.com/v1/projects -H "Accept: application/json"
 ```
+
+#### Per-invocation scopes
+
+An environment can be locked down by configuring `scopes` (e.g. `["api:read"]`) in `environments.json`. For a one-off operation that needs more, pass `--scope` instead of widening the environment config. The flag replaces the environment's configured scopes entirely for that invocation: the token is requested with exactly the scopes given. Scope values are passed to the auth server without client-side validation. Tokens are cached per scope set, so an elevated token is never returned for a request with different scopes.
+
+```bash
+# One-off write from a read-locked environment
+kog post --scope api:read --scope api:write "https://customer-import.app.kognic.com/v1/customer-imports/<uuid>/retrigger"
+```
+
+When running under Kognic's Claude Code tooling, minting a write-capable token is gated by a hook and requires an explicit per-call acknowledgment on the same command line:
+
+```bash
+KOG_SCOPE_ACK=1 kog post --scope api:read --scope api:write "https://customer-import.app.kognic.com/v1/customer-imports/<uuid>/retrigger"
+```
+
+`kog` itself does not read `KOG_SCOPE_ACK`; the gate is enforced by the tooling's hooks.
 
 #### Output formats
 

--- a/src/kognic/auth/cli/api_request.py
+++ b/src/kognic/auth/cli/api_request.py
@@ -37,6 +37,14 @@ def _create_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--env", dest="env_name", help="Force a specific environment (skip URL-based matching)")
     parser.add_argument(
+        "--scope",
+        action="append",
+        dest="scopes",
+        metavar="SCOPE",
+        help="OAuth2 scope to request (repeatable). When given, the token is requested with exactly "
+        "these scopes and the environment's configured scopes are ignored for this invocation.",
+    )
+    parser.add_argument(
         "--format",
         dest="output_format",
         choices=["json", "jsonl", "csv", "tsv", "table"],
@@ -89,7 +97,7 @@ def run(parsed: argparse.Namespace) -> int:
             auth=env.credentials,
             auth_host=env.auth_server,
             token_cache=make_cache(parsed.token_cache),
-            scopes=env.scopes or None,
+            scopes=parsed.scopes or env.scopes or None,
         )
         session = create_session(token_provider=provider)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 from kognic.auth import DEFAULT_HOST
 from kognic.auth.cli import create_parser, main
+from kognic.auth.cli.api_request import METHODS
 from kognic.auth.cli.api_request import _create_parser as create_kog_parser
 from kognic.auth.cli.api_request import run as call_run
 from kognic.auth.env_config import Environment
@@ -479,8 +480,6 @@ class KogParserTest(unittest.TestCase):
 
     def test_kog_scope_on_every_method(self):
         parser = create_kog_parser()
-        from kognic.auth.cli.api_request import METHODS
-
         for method in METHODS:
             args = parser.parse_args(["--scope", "api:read", method, "https://app.kognic.com/v1/projects"])
             self.assertEqual(args.method, method)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -456,6 +456,41 @@ class KogParserTest(unittest.TestCase):
         args = parser.parse_args(["get", "https://app.kognic.com/v1/projects", "--token-cache", "none"])
         self.assertEqual(args.token_cache, "none")
 
+    def test_kog_scope_default_none(self):
+        parser = create_kog_parser()
+        args = parser.parse_args(["get", "https://app.kognic.com/v1/projects"])
+        self.assertIsNone(args.scopes)
+
+    def test_kog_scope_repeatable(self):
+        parser = create_kog_parser()
+        args = parser.parse_args(
+            ["post", "https://app.kognic.com/v1/projects", "--scope", "api:read", "--scope", "api:write"]
+        )
+        self.assertEqual(args.scopes, ["api:read", "api:write"])
+
+    def test_kog_scope_position_independent(self):
+        parser = create_kog_parser()
+        args = parser.parse_args(
+            ["post", "--scope", "api:read", "https://app.kognic.com/v1/projects", "--scope", "api:write"]
+        )
+        self.assertEqual(args.method, "post")
+        self.assertEqual(args.url, "https://app.kognic.com/v1/projects")
+        self.assertEqual(args.scopes, ["api:read", "api:write"])
+
+    def test_kog_scope_on_every_method(self):
+        parser = create_kog_parser()
+        from kognic.auth.cli.api_request import METHODS
+
+        for method in METHODS:
+            args = parser.parse_args(["--scope", "api:read", method, "https://app.kognic.com/v1/projects"])
+            self.assertEqual(args.method, method)
+            self.assertEqual(args.scopes, ["api:read"])
+
+    def test_kog_scope_values_unvalidated(self):
+        parser = create_kog_parser()
+        args = parser.parse_args(["get", "https://app.kognic.com/v1/projects", "--scope", "anything goes here"])
+        self.assertEqual(args.scopes, ["anything goes here"])
+
 
 class CallApiTest(unittest.TestCase):
     def _make_parsed(
@@ -467,6 +502,7 @@ class CallApiTest(unittest.TestCase):
         env_config_file_path="/nonexistent/config.json",
         env_name=None,
         token_cache="none",
+        scopes=None,
     ):
         parser = create_kog_parser()
         args = [method, url]
@@ -479,6 +515,9 @@ class CallApiTest(unittest.TestCase):
         if env_name:
             args.extend(["--env", env_name])
         args.extend(["--token-cache", token_cache])
+        if scopes:
+            for scope in scopes:
+                args.extend(["--scope", scope])
         return parser.parse_args(args)
 
     @mock.patch("kognic.auth.cli.api_request.resolve_environment")
@@ -1155,6 +1194,77 @@ class CallApiTest(unittest.TestCase):
                 auth_host="https://auth.staging.kognic.com",
                 token_cache=None,
                 scopes=["api:read"],
+            )
+
+    @mock.patch("kognic.auth.cli.api_request.resolve_environment")
+    @mock.patch("kognic.auth.cli.api_request.load_kognic_env_config")
+    def test_call_api_cli_scopes_replace_env_scopes(self, mock_load_config, mock_resolve_environment):
+        """--scope replaces the environment's configured scopes entirely for this invocation."""
+        mock_load_config.return_value = mock.MagicMock()
+        mock_resolve_environment.return_value = Environment(
+            name="production",
+            host="app.kognic.com",
+            auth_server="https://auth.app.kognic.com",
+            credentials="/path/to/prod-creds.json",
+            scopes=["api:read"],
+        )
+
+        with (
+            mock.patch("kognic.auth.cli.api_request.make_token_provider") as mock_make_provider,
+            mock.patch("kognic.auth.cli.api_request.create_session") as mock_create_session,
+        ):
+            mock_session = mock.MagicMock()
+            mock_response = mock.MagicMock()
+            mock_response.ok = True
+            mock_response.headers = {"Content-Type": "text/plain"}
+            mock_response.text = "ok"
+            mock_session.request.return_value = mock_response
+            mock_create_session.return_value = mock_session
+
+            parsed = self._make_parsed(method="post", scopes=["api:read", "api:write"])
+            with mock.patch("builtins.print"):
+                call_run(parsed)
+
+            mock_make_provider.assert_called_once_with(
+                auth="/path/to/prod-creds.json",
+                auth_host="https://auth.app.kognic.com",
+                token_cache=None,
+                scopes=["api:read", "api:write"],
+            )
+
+    @mock.patch("kognic.auth.cli.api_request.resolve_environment")
+    @mock.patch("kognic.auth.cli.api_request.load_kognic_env_config")
+    def test_call_api_cli_scopes_without_env_scopes(self, mock_load_config, mock_resolve_environment):
+        """--scope applies even when the environment has no configured scopes."""
+        mock_load_config.return_value = mock.MagicMock()
+        mock_resolve_environment.return_value = Environment(
+            name="default",
+            host="app.kognic.com",
+            auth_server="https://auth.app.kognic.com",
+            credentials=None,
+        )
+
+        with (
+            mock.patch("kognic.auth.cli.api_request.make_token_provider") as mock_make_provider,
+            mock.patch("kognic.auth.cli.api_request.create_session") as mock_create_session,
+        ):
+            mock_session = mock.MagicMock()
+            mock_response = mock.MagicMock()
+            mock_response.ok = True
+            mock_response.headers = {"Content-Type": "text/plain"}
+            mock_response.text = "ok"
+            mock_session.request.return_value = mock_response
+            mock_create_session.return_value = mock_session
+
+            parsed = self._make_parsed(scopes=["custom:scope"])
+            with mock.patch("builtins.print"):
+                call_run(parsed)
+
+            mock_make_provider.assert_called_once_with(
+                auth=None,
+                auth_host="https://auth.app.kognic.com",
+                token_cache=None,
+                scopes=["custom:scope"],
             )
 
     @mock.patch("kognic.auth.cli.api_request.resolve_environment")


### PR DESCRIPTION
Closes annotell/kognic-soleng#1661 (sub-issue of annotell/kognic-soleng#1657).

## What

A repeatable, position-independent `--scope` flag on `kog`, so a one-off elevated operation (e.g. a production write) no longer requires widening the environment config:

```bash
kog post --scope api:read --scope api:write "https://customer-import.app.kognic.com/v1/customer-imports/<uuid>/retrigger"
```

- **Replace semantics**: when `--scope` is given, the token request carries exactly those scopes; the environment's configured scopes are ignored for that invocation. Without the flag, behavior is unchanged.
- No library/cache changes needed: the token cache already keys by scope set, so an elevated token is never returned for a differently-scoped request.