### PR TITLE
build: ship a LICENSE file and adopt PEP 639 license metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) Kognic AB
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-  "setuptools>45",
-  "setuptools_scm[toml]>=6.2"
+  "setuptools>=77",
+  "setuptools-scm>=10.0.5"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -19,10 +19,10 @@ dependencies = [
 requires-python=">=3.10"
 readme = "README.md"
 keywords = ["Kognic", "API"]
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
 ]
@@ -36,7 +36,10 @@ kognic-auth = "kognic.auth.cli:main"
 kog = "kognic.auth.cli.api_request:main"
 
 [tool.setuptools_scm]
-write_to = "src/kognic/auth/_version.py"
+version_file = "src/kognic/auth/_version.py"
+# kognic.auth imports __version__ from the generated file, so it has to reach
+# the source tree and not only the build directory.
+write_to_source = true
 
 [project.optional-dependencies]
 httpx = [


### PR DESCRIPTION
Part of annotell/kognic-soleng#1624. Mirrors annotell/kognic-io-python#266 + #267 — the LICENSE text is byte-identical to the legally approved one there.

## What

- `LICENSE` at the repo root: canonical SPDX MIT text, notice line `Copyright (c) Kognic AB`, no year, declared via `project.license-files`.
- PEP 639 metadata: `license = "MIT"`, drop the MIT classifier, `setuptools>=77` + `setuptools-scm>=10.0.5`, `write_to` → `version_file` (+ `write_to_source`, since `kognic.auth` imports `__version__` from the generated file).

The published 4.4.2 wheel carries `License: MIT` and zero license files.

## Verification

`uv build` under `PYTHONWARNINGS=always`: no warnings; wheel has `Metadata-Version: 2.4`, `License-Expression: MIT`, `License-File: LICENSE`; LICENSE byte-identical to source in both wheel and sdist. 218 tests pass.